### PR TITLE
fix: redirect cart continue shopping to dashboard

### DIFF
--- a/frontend_updated_for_api/app/cart/page.tsx
+++ b/frontend_updated_for_api/app/cart/page.tsx
@@ -174,7 +174,7 @@ export default function CartPage() {
                     <Link href="/checkout">Proceed to Checkout</Link>
                   </Button>
                   <Button variant="outline" className="w-full rounded-xl bg-transparent" asChild>
-                    <Link href="/courses">Continue Shopping</Link>
+                    <Link href="/dashboard">Continue Shopping</Link>
                   </Button>
                 </div>
 


### PR DESCRIPTION
## Summary
- redirect Continue Shopping button on cart page to `/dashboard`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for interactive Next.js ESLint setup)

------
https://chatgpt.com/codex/tasks/task_e_68c206a6b4b083219311352423cdd190