### PR TITLE
fix: redirect cart navigation to dashboard

### DIFF
--- a/frontend_updated_for_api/app/cart/page.tsx
+++ b/frontend_updated_for_api/app/cart/page.tsx
@@ -27,7 +27,7 @@ export default function CartPage() {
         <header className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4 flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <Link href="/courses" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
+              <Link href="/dashboard" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
                 <ArrowLeft className="w-5 h-5" />
                 <span>Back to Courses</span>
               </Link>
@@ -62,7 +62,7 @@ export default function CartPage() {
       <header className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Link href="/courses" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
+            <Link href="/dashboard" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
               <ArrowLeft className="w-5 h-5" />
               <span>Back to Courses</span>
             </Link>
@@ -174,7 +174,7 @@ export default function CartPage() {
                     <Link href="/checkout">Proceed to Checkout</Link>
                   </Button>
                   <Button variant="outline" className="w-full rounded-xl bg-transparent" asChild>
-                    <Link href="/courses">Continue Shopping</Link>
+                    <Link href="/dashboard">Continue Shopping</Link>
                   </Button>
                 </div>
 


### PR DESCRIPTION
## Summary
- route cart "Back to Courses" links to `/dashboard`
- ensure cart navigation buttons use relative `/dashboard` path

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for interactive Next.js ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68c206a6b4b083219311352423cdd190