### PR TITLE
feat: add sign out buttons to dashboards and fix cart redirects

### DIFF
--- a/frontend_updated_for_api/app/cart/page.tsx
+++ b/frontend_updated_for_api/app/cart/page.tsx
@@ -27,7 +27,7 @@ export default function CartPage() {
         <header className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4 flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <Link href="/courses" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
+              <Link href="/dashboard" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
                 <ArrowLeft className="w-5 h-5" />
                 <span>Back to Courses</span>
               </Link>
@@ -62,7 +62,7 @@ export default function CartPage() {
       <header className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Link href="/courses" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
+            <Link href="/dashboard" className="flex items-center gap-2 text-gray-600 hover:text-blue-600">
               <ArrowLeft className="w-5 h-5" />
               <span>Back to Courses</span>
             </Link>
@@ -174,7 +174,7 @@ export default function CartPage() {
                     <Link href="/checkout">Proceed to Checkout</Link>
                   </Button>
                   <Button variant="outline" className="w-full rounded-xl bg-transparent" asChild>
-                    <Link href="/courses">Continue Shopping</Link>
+                    <Link href="/dashboard">Continue Shopping</Link>
                   </Button>
                 </div>
 

--- a/frontend_updated_for_api/app/dashboard/page.tsx
+++ b/frontend_updated_for_api/app/dashboard/page.tsx
@@ -44,7 +44,7 @@ async function api<T>(path: string, userId?: number, init?: RequestInit): Promis
 }
 
 export default function DashboardPage() {
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, logout } = useAuth()
   const { state, dispatch } = useCart()
 
   const [mounted, setMounted] = useState(false)
@@ -54,6 +54,11 @@ export default function DashboardPage() {
   const [allCourses, setAllCourses] = useState<any[]>([])
   const [showAllCourses, setShowAllCourses] = useState(false)
   const [searchTerm, setSearchTerm] = useState("")
+
+  const handleLogout = () => {
+    logout()
+    window.location.href = "http://localhost:3000"
+  }
 
   useEffect(() => setMounted(true), [])
 
@@ -170,8 +175,8 @@ export default function DashboardPage() {
                     )}
                   </Link>
                 </Button>
-                <Button variant="outline" asChild>
-                  <Link href="/logout">Sign Out</Link>
+                <Button variant="outline" onClick={handleLogout}>
+                  Sign Out
                 </Button>
               </div>
             </div>

--- a/frontend_updated_for_api/app/parent/dashboard/page.tsx
+++ b/frontend_updated_for_api/app/parent/dashboard/page.tsx
@@ -14,6 +14,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/lib/auth-context";
 import { apiFetch, API_BASE } from "@/lib/api";
 
+const FRONTEND_ORIGIN =
+  process.env.NEXT_PUBLIC_FRONTEND_ORIGIN ?? "http://localhost:3000";
+
 type Payment = {
   id: number;
   amount: number;
@@ -57,12 +60,17 @@ const childrenSeed: ChildCard[] = [
 ];
 
 export default function ParentDashboard() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const displayName = user?.name ?? "Parent";
   const userEmail   = user?.email ?? "";
 
   const [payments, setPayments] = useState<Payment[]>([]);
   const [loadingPayments, setLoadingPayments] = useState(false);
+
+  const handleSignOut = () => {
+    logout();
+    window.location.href = FRONTEND_ORIGIN;
+  };
 
   useEffect(() => {
     if (!user?.id) return;
@@ -120,6 +128,9 @@ export default function ParentDashboard() {
               <Button variant="outline" size="sm">
                 <Settings className="w-4 h-4 mr-2" />
                 Settings
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleSignOut}>
+                Sign Out
               </Button>
               <div className="flex items-center gap-2">
                 <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">

--- a/frontend_updated_for_api/app/student/dashboard/page.tsx
+++ b/frontend_updated_for_api/app/student/dashboard/page.tsx
@@ -22,6 +22,8 @@ import {
 } from "lucide-react"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
+const FRONTEND_ORIGIN =
+  process.env.NEXT_PUBLIC_FRONTEND_ORIGIN ?? "http://localhost:3000"
 
 // small helper that always sets JSON + X-User-Id header (if userId provided)
 async function api<T>(path: string, userId?: number, init?: RequestInit): Promise<T> {
@@ -42,7 +44,7 @@ async function api<T>(path: string, userId?: number, init?: RequestInit): Promis
 }
 
 export default function StudentDashboard() {
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, logout } = useAuth()
   const { state, dispatch } = useCart()
 
   const [mounted, setMounted] = useState(false)
@@ -52,6 +54,11 @@ export default function StudentDashboard() {
   const [allCourses, setAllCourses] = useState<any[]>([])
   const [showAllCourses, setShowAllCourses] = useState(false)
   const [searchTerm, setSearchTerm] = useState("")
+
+  const handleSignOut = () => {
+    logout()
+    window.location.href = FRONTEND_ORIGIN
+  }
 
   useEffect(() => setMounted(true), [])
 
@@ -141,6 +148,9 @@ export default function StudentDashboard() {
             <div className="flex items-center gap-4">
               <Button variant="outline" size="sm" className="rounded-full bg-transparent" asChild>
                 <Link href="/parent/dashboard">Parent View</Link>
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleSignOut}>
+                Sign Out
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- route cart "Back to Courses" links to `/dashboard`
- ensure cart navigation buttons use relative `/dashboard` path
- redirect dashboard sign out to frontend home and clear auth state
- add parent and student dashboard sign out buttons that log out and redirect to configured frontend origin

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for Next.js ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c206a6b4b083219311352423cdd190