### PR TITLE
feat: add course picture migration

### DIFF
--- a/backend 2/learn2code/src/main/resources/db/migration/V1__init.sql
+++ b/backend 2/learn2code/src/main/resources/db/migration/V1__init.sql
@@ -58,11 +58,3 @@ CREATE TABLE IF NOT EXISTS user_courses (
 CREATE INDEX IF NOT EXISTS idx_user_courses_user ON user_courses(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_courses_course ON user_courses(course_id);
 
--- Add course pictures
-ALTER TABLE courses ADD COLUMN IF NOT EXISTS picture VARCHAR(255);
-
-UPDATE courses SET picture = 'https://example.com/images/python.png' WHERE title = 'Python Basics';
-UPDATE courses SET picture = 'https://example.com/images/js.png' WHERE title = 'JavaScript Fundamentals';
-UPDATE courses SET picture = 'https://example.com/images/web.png' WHERE title = 'Web Design Magic';
-UPDATE courses SET picture = 'https://example.com/images/scratch.png' WHERE title = 'Scratch Basics';
-UPDATE courses SET picture = 'https://example.com/images/ml.png' WHERE title = 'Machine Learning 101';

--- a/backend 2/learn2code/src/main/resources/db/migration/V4__add_course_pictures.sql
+++ b/backend 2/learn2code/src/main/resources/db/migration/V4__add_course_pictures.sql
@@ -1,0 +1,41 @@
+ALTER TABLE courses ADD COLUMN IF NOT EXISTS picture VARCHAR(500);
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg'
+WHERE name = 'Python Basics';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg'
+WHERE name = 'Java Programming';
+
+UPDATE courses 
+SET picture = 'https://upload.wikimedia.org/wikipedia/commons/3/3d/Scratch_cat.svg'
+WHERE name = 'Scratch for Kids';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg'
+WHERE name = 'Web Development (HTML/CSS/JS)';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg'
+WHERE name = 'React.js Fundamentals';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg'
+WHERE name = 'C++ for Beginners';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postgresql/postgresql-original.svg'
+WHERE name = 'SQL & Databases';
+
+UPDATE courses 
+SET picture = 'https://upload.wikimedia.org/wikipedia/commons/5/54/Antu_applications-utilities.svg'
+WHERE name = 'Cybersecurity Basics';
+
+UPDATE courses 
+SET picture = 'https://upload.wikimedia.org/wikipedia/commons/0/05/Scikit_learn_logo_small.svg'
+WHERE name = 'Data Science with Python';
+
+UPDATE courses 
+SET picture = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/flutter/flutter-original.svg'
+WHERE name = 'Mobile Development with Flutter';


### PR DESCRIPTION
## Summary
- remove outdated course picture updates from initial migration
- populate new course picture URLs in V4 Flyway migration

## Testing
- `sqlite3 tmp.db "SELECT id, name, picture FROM courses;"`
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c47fd0cb1483219d56b883878c5d3a